### PR TITLE
Fix interactive download crash when no courses are selected

### DIFF
--- a/src/canvasctl/cli.py
+++ b/src/canvasctl/cli.py
@@ -572,7 +572,10 @@ def download_interactive(
             console.print("[yellow]No active courses available.[/yellow]")
             return 0
 
-        selection = prompt_interactive_selection(all_courses)
+        try:
+            selection = prompt_interactive_selection(all_courses)
+        except RuntimeError as exc:
+            _fail(str(exc))
         selected_map = {course.id: course for course in all_courses}
         selected_courses = [
             selected_map[course_id]


### PR DESCRIPTION
## Summary
- catch interactive selection RuntimeError in download flow and surface it as a standard CLI error
- prevent raw Python traceback from being shown to users in this path
- add regression test covering the no-selection prompt error path

## Testing
- uv run pytest tests/test_cli_download.py -q
- uv run pytest -q