### PR TITLE
Switch CLI command to cvsctl and brand product as canvas-control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# canvasctl
+# canvas-control
 
-`canvasctl` turns Canvas into a fast, scriptable download pipeline.
+`canvas-control` turns Canvas into a fast, scriptable download pipeline.
 
 Instead of clicking through files one-by-one, you can:
 
@@ -9,7 +9,7 @@ Instead of clicking through files one-by-one, you can:
 - use interactive prompts when you want guidance
 - generate manifests so failed downloads can be resumed
 
-## Why canvasctl is powerful
+## Why canvas-control is powerful
 
 - One command can download from `files`, `assignments`, `discussions`, `pages`, and `modules`.
 - It is built for repeatable workflows: predictable output paths and machine-readable manifests.
@@ -18,7 +18,7 @@ Instead of clicking through files one-by-one, you can:
 
 ## Quick start
 
-`canvasctl` uses [uv](https://docs.astral.sh/uv/) for environment and dependency management.
+`canvas-control` uses [uv](https://docs.astral.sh/uv/) for environment and dependency management.
 
 1. Create and activate a virtual environment (Python 3.12+):
 
@@ -36,15 +36,15 @@ uv pip install -e '.[dev]'
 3. Set your Canvas base URL once:
 
 ```bash
-canvasctl config set-base-url https://your-school.instructure.com
+cvsctl config set-base-url https://your-school.instructure.com
 ```
 
-4. Set `CANVAS_TOKEN` (recommended) or let `canvasctl` prompt for it.
+4. Set `CANVAS_TOKEN` (recommended) or let `cvsctl` prompt for it.
 
 5. Run your first command:
 
 ```bash
-canvasctl courses list
+cvsctl courses list
 ```
 
 ## Set `CANVAS_TOKEN`
@@ -73,31 +73,31 @@ Tips so you do not copy/paste every time:
 List courses, then download one by ID:
 
 ```bash
-canvasctl courses list
-canvasctl download run --course 12345
+cvsctl courses list
+cvsctl download run --course 12345
 ```
 
 Download two courses in one command:
 
 ```bash
-canvasctl download run --course 12345 --course 67890
+cvsctl download run --course 12345 --course 67890
 ```
 
 Limit sources to just files + assignments:
 
 ```bash
-canvasctl download run --course 12345 --source files --source assignments
+cvsctl download run --course 12345 --source files --source assignments
 ```
 
 Overwrite existing files:
 
 ```bash
-canvasctl download run --course 12345 --overwrite true
+cvsctl download run --course 12345 --overwrite true
 ```
 
 ## Configuration deep-dive
 
-`canvasctl` has two destination concepts:
+`canvas-control` has two destination concepts:
 
 - `default_dest`: saved path in config
 - `effective_dest`: active path for this run
@@ -107,31 +107,31 @@ If no destination is configured, downloads default to `./downloads`.
 Show current config:
 
 ```bash
-canvasctl config show
+cvsctl config show
 ```
 
 Set a persistent default download location:
 
 ```bash
-canvasctl config set-download-path ~/Downloads/canvas-files
+cvsctl config set-download-path ~/Downloads/canvas-files
 ```
 
 Clear the persistent default:
 
 ```bash
-canvasctl config clear-download-path
+cvsctl config clear-download-path
 ```
 
 Use a one-off destination without saving it:
 
 ```bash
-canvasctl download run --course 12345 --dest ~/Desktop/tmp-canvas
+cvsctl download run --course 12345 --dest ~/Desktop/tmp-canvas
 ```
 
 Use and save a destination in one step:
 
 ```bash
-canvasctl download run --course 12345 --dest ~/Downloads/canvas-files --export-dest
+cvsctl download run --course 12345 --dest ~/Downloads/canvas-files --export-dest
 ```
 
 ## Interactive mode
@@ -139,13 +139,13 @@ canvasctl download run --course 12345 --dest ~/Downloads/canvas-files --export-d
 If you want a guided flow (choose courses, sources, and possibly file-level selection), use:
 
 ```bash
-canvasctl download interactive
+cvsctl download interactive
 ```
 
 You can still provide overrides:
 
 ```bash
-canvasctl download interactive --dest ~/Downloads/canvas-files --export-dest --concurrency 16
+cvsctl download interactive --dest ~/Downloads/canvas-files --export-dest --concurrency 16
 ```
 
 ## Resume failed downloads
@@ -153,7 +153,7 @@ canvasctl download interactive --dest ~/Downloads/canvas-files --export-dest --c
 Every run writes manifest files. To retry anything marked `failed` or `pending`:
 
 ```bash
-canvasctl download resume --manifest /path/to/.canvasctl-runs/<run-id>.json
+cvsctl download resume --manifest /path/to/.canvasctl-runs/<run-id>.json
 ```
 
 This is ideal for flaky networks or large course downloads.
@@ -162,14 +162,14 @@ This is ideal for flaky networks or large course downloads.
 
 Current command tree:
 
-- `canvasctl config set-base-url <url>`
-- `canvasctl config set-download-path <path>`
-- `canvasctl config clear-download-path`
-- `canvasctl config show`
-- `canvasctl courses list [--all] [--json] [--base-url <url>]`
-- `canvasctl download run --course <id-or-code>... [--source <source>...] [--dest <path>] [--export-dest] [--overwrite <bool>] [--force] [--concurrency <n>] [--base-url <url>]`
-- `canvasctl download interactive [--dest <path>] [--export-dest] [--base-url <url>] [--concurrency <n>] [--force]`
-- `canvasctl download resume --manifest <path>`
+- `cvsctl config set-base-url <url>`
+- `cvsctl config set-download-path <path>`
+- `cvsctl config clear-download-path`
+- `cvsctl config show`
+- `cvsctl courses list [--all] [--json] [--base-url <url>]`
+- `cvsctl download run --course <id-or-code>... [--source <source>...] [--dest <path>] [--export-dest] [--overwrite <bool>] [--force] [--concurrency <n>] [--base-url <url>]`
+- `cvsctl download interactive [--dest <path>] [--export-dest] [--base-url <url>] [--concurrency <n>] [--force]`
+- `cvsctl download resume --manifest <path>`
 
 Available `--source` values:
 
@@ -196,16 +196,16 @@ Behavior notes:
 401 / token rejected:
 
 - update `CANVAS_TOKEN` and retry
-- or unset it and let `canvasctl` prompt you again
+- or unset it and let `cvsctl` prompt you again
 
 No base URL configured:
 
-- run `canvasctl config set-base-url https://your-school.instructure.com`
+- run `cvsctl config set-base-url https://your-school.instructure.com`
 
 No files downloaded:
 
 - check source filters (`--source`)
-- run `canvasctl courses list --all` to verify course visibility/state
+- run `cvsctl courses list --all` to verify course visibility/state
 - use `download interactive` to inspect course/file selections
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,12 @@ requires = ["hatchling>=1.24.2"]
 build-backend = "hatchling.build"
 
 [project]
-name = "canvasctl"
+name = "canvas-control"
 version = "0.1.0"
 description = "Canvas LMS CLI for listing courses and downloading course files"
 readme = "README.md"
 requires-python = ">=3.12"
-authors = [{ name = "canvasctl contributors" }]
+authors = [{ name = "canvas-control contributors" }]
 dependencies = [
   "httpx>=0.27.0,<1.0.0",
   "platformdirs>=4.2.0,<5.0.0",
@@ -26,7 +26,10 @@ dev = [
 ]
 
 [project.scripts]
-canvasctl = "canvasctl.cli:main"
+cvsctl = "canvasctl.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/canvasctl"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts
 
-Optional utilities that use canvasctl. Install the project first: `uv pip install -e .`
+Optional utilities that use canvas-control. Install the project first: `uv pip install -e .`
 
 ## canvas-health-check.py
 

--- a/scripts/canvas-health-check.py
+++ b/scripts/canvas-health-check.py
@@ -2,9 +2,9 @@
 """
 Canvas connectivity health check.
 
-Uses canvasctl config, auth, and API client to verify that the configured
-Canvas base URL and token work. Does not modify any canvasctl state.
-Run from project root after installing canvasctl (e.g. uv pip install -e .):
+Uses canvas-control config, auth, and API client to verify that the configured
+Canvas base URL and token work. Does not modify any canvas-control state.
+Run from project root after installing canvas-control (e.g. uv pip install -e .):
 
     python scripts/canvas-health-check.py
     python scripts/canvas-health-check.py --base-url https://your-school.instructure.com
@@ -85,7 +85,7 @@ def main() -> int:
         "--base-url",
         type=str,
         default=None,
-        help="Override Canvas instance URL (otherwise uses canvasctl config).",
+        help="Override Canvas instance URL (otherwise uses canvas-control config).",
     )
     args = parser.parse_args()
     return _run_health_check(args.base_url)

--- a/src/canvasctl/__init__.py
+++ b/src/canvasctl/__init__.py
@@ -1,4 +1,4 @@
-"""canvasctl package."""
+"""canvas-control package."""
 
 __all__ = ["__version__"]
 __version__ = "0.1.0"

--- a/src/canvasctl/cli.py
+++ b/src/canvasctl/cli.py
@@ -54,7 +54,7 @@ from canvasctl.sources import (
 )
 
 app = typer.Typer(help="Canvas LMS CLI")
-config_app = typer.Typer(help="Manage local canvasctl config")
+config_app = typer.Typer(help="Manage local cvsctl config")
 courses_app = typer.Typer(help="List and inspect courses")
 download_app = typer.Typer(help="Download course files")
 
@@ -224,7 +224,7 @@ def _resolve_courses_from_selectors(
 
 
 def _render_config_table(cfg: AppConfig) -> Table:
-    table = Table(title="canvasctl Config")
+    table = Table(title="cvsctl Config")
     table.add_column("Key", style="cyan")
     table.add_column("Value")
     table.add_row("base_url", cfg.base_url or "")

--- a/src/canvasctl/config.py
+++ b/src/canvasctl/config.py
@@ -9,7 +9,7 @@ import platformdirs
 import tomllib
 import tomli_w
 
-APP_NAME = "canvasctl"
+APP_NAME = "canvas-control"
 DEFAULT_CONCURRENCY = 12
 
 
@@ -142,5 +142,5 @@ def resolve_base_url(base_url_override: str | None, cfg: AppConfig) -> str:
     if cfg.base_url:
         return cfg.base_url
     raise ConfigError(
-        "Canvas base URL is required. Use --base-url or run 'canvasctl config set-base-url <url>'."
+        "Canvas base URL is required. Use --base-url or run 'cvsctl config set-base-url <url>'."
     )

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ wheels = [
 ]
 
 [[package]]
-name = "canvasctl"
+name = "canvas-control"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- rename the packaged project metadata to canvas-control
- switch the installed CLI command from canvasctl to cvsctl
- update user-facing CLI/config messaging and README examples to use cvsctl
- keep module/package internals under canvasctl for code compatibility
- add explicit Hatch wheel package selection so editable builds still work after product rename

## Verification
- uv run pytest (35 passed, 1 skipped)
- uv run cvsctl --help
