### PR TITLE
feat: add `canvasctl grades summary` command

### DIFF
--- a/src/canvasctl/cli.py
+++ b/src/canvasctl/cli.py
@@ -13,9 +13,11 @@ from rich.table import Table
 
 from canvasctl.auth import AuthError, TokenInfo, prompt_for_token, resolve_token
 from canvasctl.canvas_api import (
+    AssignmentGrade,
     CanvasApiError,
     CanvasClient,
     CanvasUnauthorizedError,
+    CourseGrade,
     CourseSummary,
     RemoteFile,
 )
@@ -30,6 +32,14 @@ from canvasctl.config import (
     set_default_destination,
 )
 from canvasctl.courses import course_to_dict, render_courses_table, sort_courses
+from canvasctl.grades import (
+    assignment_grade_to_dict,
+    grade_to_dict,
+    render_detailed_grades_table,
+    render_grades_summary_table,
+    sort_assignment_grades,
+    sort_grades,
+)
 from canvasctl.downloader import (
     DownloadTask,
     build_course_slug,
@@ -57,10 +67,12 @@ app = typer.Typer(help="Canvas LMS CLI")
 config_app = typer.Typer(help="Manage local canvasctl config")
 courses_app = typer.Typer(help="List and inspect courses")
 download_app = typer.Typer(help="Download course files")
+grades_app = typer.Typer(help="View course grades")
 
 app.add_typer(config_app, name="config")
 app.add_typer(courses_app, name="courses")
 app.add_typer(download_app, name="download")
+app.add_typer(grades_app, name="grades")
 
 console = Console()
 
@@ -466,6 +478,88 @@ def courses_list(
             console.print(json.dumps(payload, indent=2))
         else:
             console.print(render_courses_table(courses))
+        return 0
+
+    _run_with_client(resolved_base_url, action)
+
+
+@grades_app.command("summary")
+def grades_summary(
+    all_courses: bool = typer.Option(False, "--all", help="Include non-active courses."),
+    detailed: bool = typer.Option(
+        False, "--detailed", help="Show per-assignment grade breakdown."
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON output."),
+    course_selectors: list[str] | None = typer.Option(
+        None,
+        "--course",
+        "-c",
+        help="Course ID or course code. Use multiple times to filter.",
+    ),
+    base_url: str | None = typer.Option(
+        None, "--base-url", help="Canvas instance URL override."
+    ),
+) -> None:
+    """Show grade summary for enrolled courses."""
+    cfg = _load_config_or_fail()
+    resolved_base_url = _resolve_base_url_or_fail(cfg, base_url)
+
+    def action(client: CanvasClient) -> int:
+        all_grades = sort_grades(
+            client.list_courses_with_grades(include_all=all_courses)
+        )
+
+        if course_selectors:
+            course_summaries = [
+                CourseSummary(
+                    id=g.course_id,
+                    course_code=g.course_code,
+                    name=g.course_name,
+                    workflow_state=None,
+                    term_name=None,
+                    start_at=None,
+                    end_at=None,
+                )
+                for g in all_grades
+            ]
+            selected = _resolve_courses_from_selectors(
+                course_summaries, course_selectors
+            )
+            selected_ids = {c.id for c in selected}
+            all_grades = [g for g in all_grades if g.course_id in selected_ids]
+
+        if not detailed:
+            if json_output:
+                payload = [grade_to_dict(g) for g in all_grades]
+                console.print(json.dumps(payload, indent=2))
+            else:
+                console.print(render_grades_summary_table(all_grades))
+        else:
+            if json_output:
+                payload = []
+                for course_grade in all_grades:
+                    assignments = sort_assignment_grades(
+                        client.list_assignment_grades(course_grade.course_id)
+                    )
+                    payload.append(
+                        {
+                            "course": grade_to_dict(course_grade),
+                            "assignments": [
+                                assignment_grade_to_dict(a) for a in assignments
+                            ],
+                        }
+                    )
+                console.print(json.dumps(payload, indent=2))
+            else:
+                for course_grade in all_grades:
+                    assignments = sort_assignment_grades(
+                        client.list_assignment_grades(course_grade.course_id)
+                    )
+                    console.print(
+                        render_detailed_grades_table(course_grade, assignments)
+                    )
+                    console.print()
+
         return 0
 
     _run_with_client(resolved_base_url, action)

--- a/src/canvasctl/grades.py
+++ b/src/canvasctl/grades.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from rich.table import Table
+
+from canvasctl.canvas_api import AssignmentGrade, CourseGrade
+
+
+def grade_to_dict(grade: CourseGrade) -> dict[str, str | int | float | None]:
+    return asdict(grade)
+
+
+def assignment_grade_to_dict(grade: AssignmentGrade) -> dict[str, str | int | float | None]:
+    return asdict(grade)
+
+
+def sort_grades(grades: list[CourseGrade]) -> list[CourseGrade]:
+    return sorted(
+        grades,
+        key=lambda g: (g.course_code.lower(), g.course_name.lower(), g.course_id),
+    )
+
+
+def sort_assignment_grades(grades: list[AssignmentGrade]) -> list[AssignmentGrade]:
+    return sorted(
+        grades,
+        key=lambda g: (g.assignment_name.lower(), g.assignment_id),
+    )
+
+
+def render_grades_summary_table(grades: list[CourseGrade]) -> Table:
+    table = Table(title="Course Grades")
+    table.add_column("ID", style="cyan", justify="right")
+    table.add_column("Course Code", style="magenta")
+    table.add_column("Course Name", style="bold")
+    table.add_column("Letter Grade", justify="center")
+    table.add_column("Score (%)", justify="right")
+
+    for grade in grades:
+        score_str = f"{grade.current_score:.1f}" if grade.current_score is not None else "N/A"
+        letter_str = grade.current_grade or "N/A"
+        table.add_row(
+            str(grade.course_id),
+            grade.course_code,
+            grade.course_name,
+            letter_str,
+            score_str,
+        )
+
+    return table
+
+
+def render_detailed_grades_table(
+    course_grade: CourseGrade,
+    assignment_grades: list[AssignmentGrade],
+) -> Table:
+    title = f"Grades: {course_grade.course_code} - {course_grade.course_name}"
+    table = Table(title=title)
+    table.add_column("Assignment", style="bold")
+    table.add_column("Score", justify="right")
+    table.add_column("Possible", justify="right")
+    table.add_column("Grade")
+    table.add_column("Status")
+
+    for ag in assignment_grades:
+        score_str = str(ag.score) if ag.score is not None else "-"
+        possible_str = str(ag.points_possible) if ag.points_possible is not None else "-"
+        grade_str = ag.grade or "-"
+        status_str = ag.workflow_state or "-"
+        table.add_row(
+            ag.assignment_name,
+            score_str,
+            possible_str,
+            grade_str,
+            status_str,
+        )
+
+    overall_letter = course_grade.current_grade or "N/A"
+    overall_score = (
+        f"{course_grade.current_score:.1f}%"
+        if course_grade.current_score is not None
+        else "N/A"
+    )
+    table.add_section()
+    table.add_row(
+        "OVERALL",
+        overall_score,
+        "",
+        overall_letter,
+        "",
+        style="bold green",
+    )
+
+    return table

--- a/tests/test_canvas_api.py
+++ b/tests/test_canvas_api.py
@@ -50,6 +50,87 @@ def test_retry_on_429(monkeypatch):
     assert call_count["value"] == 2
 
 
+def test_list_courses_with_grades_parses_enrollments(monkeypatch):
+    monkeypatch.setattr("canvasctl.canvas_api.time.sleep", lambda _: None)
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("https://canvas.test/api/v1/courses").respond(
+            200,
+            json=[
+                {
+                    "id": 100,
+                    "course_code": "BIO101",
+                    "name": "Biology",
+                    "enrollments": [
+                        {
+                            "type": "student",
+                            "computed_current_score": 92.5,
+                            "computed_current_grade": "A-",
+                        }
+                    ],
+                },
+                {
+                    "id": 200,
+                    "course_code": "MATH201",
+                    "name": "Calculus",
+                    "enrollments": [],
+                },
+            ],
+        )
+
+        with CanvasClient("https://canvas.test", "token") as client:
+            grades = client.list_courses_with_grades(include_all=False)
+
+    assert len(grades) == 2
+    assert grades[0].course_id == 100
+    assert grades[0].course_code == "BIO101"
+    assert grades[0].current_score == 92.5
+    assert grades[0].current_grade == "A-"
+    assert grades[1].course_id == 200
+    assert grades[1].current_score is None
+    assert grades[1].current_grade is None
+
+
+def test_list_assignment_grades_parses_submissions(monkeypatch):
+    monkeypatch.setattr("canvasctl.canvas_api.time.sleep", lambda _: None)
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("https://canvas.test/api/v1/courses/100/assignments").respond(
+            200,
+            json=[
+                {
+                    "id": 10,
+                    "name": "Homework 1",
+                    "points_possible": 100.0,
+                    "submission": {
+                        "score": 95.0,
+                        "grade": "A",
+                        "submitted_at": "2025-01-15T10:00:00Z",
+                        "workflow_state": "graded",
+                    },
+                },
+                {
+                    "id": 11,
+                    "name": "Quiz 1",
+                    "points_possible": 50.0,
+                    "submission": None,
+                },
+            ],
+        )
+
+        with CanvasClient("https://canvas.test", "token") as client:
+            grades = client.list_assignment_grades(100)
+
+    assert len(grades) == 2
+    assert grades[0].assignment_id == 10
+    assert grades[0].score == 95.0
+    assert grades[0].grade == "A"
+    assert grades[0].workflow_state == "graded"
+    assert grades[1].assignment_id == 11
+    assert grades[1].score is None
+    assert grades[1].grade is None
+
+
 def test_get_paginated_detects_loop(monkeypatch):
     monkeypatch.setattr("canvasctl.canvas_api.time.sleep", lambda _: None)
 

--- a/tests/test_cli_grades.py
+++ b/tests/test_cli_grades.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from canvasctl.canvas_api import AssignmentGrade, CourseGrade
+from canvasctl.cli import app
+from canvasctl.config import AppConfig
+
+
+class FakeClient:
+    def list_courses_with_grades(self, *, include_all: bool):
+        assert include_all is False
+        return [
+            CourseGrade(
+                course_id=100,
+                course_code="BIO101",
+                course_name="Biology",
+                current_score=92.5,
+                current_grade="A-",
+            ),
+            CourseGrade(
+                course_id=200,
+                course_code="MATH201",
+                course_name="Calculus",
+                current_score=87.0,
+                current_grade="B+",
+            ),
+        ]
+
+    def list_assignment_grades(self, course_id: int):
+        return [
+            AssignmentGrade(
+                assignment_id=10,
+                assignment_name="Homework 1",
+                course_id=course_id,
+                points_possible=100.0,
+                score=95.0,
+                grade="A",
+                submitted_at="2025-01-15T10:00:00Z",
+                workflow_state="graded",
+            ),
+            AssignmentGrade(
+                assignment_id=11,
+                assignment_name="Midterm",
+                course_id=course_id,
+                points_possible=200.0,
+                score=170.0,
+                grade="B+",
+                submitted_at="2025-02-10T14:00:00Z",
+                workflow_state="graded",
+            ),
+        ]
+
+
+class FakeClientAll:
+    """FakeClient that expects include_all=True."""
+
+    def list_courses_with_grades(self, *, include_all: bool):
+        assert include_all is True
+        return [
+            CourseGrade(
+                course_id=100,
+                course_code="BIO101",
+                course_name="Biology",
+                current_score=92.5,
+                current_grade="A-",
+            ),
+        ]
+
+
+def _patch(monkeypatch, fake_client=None):
+    if fake_client is None:
+        fake_client = FakeClient()
+    monkeypatch.setattr(
+        "canvasctl.cli._load_config_or_fail",
+        lambda: AppConfig(base_url="https://canvas.test"),
+    )
+    monkeypatch.setattr(
+        "canvasctl.cli._resolve_base_url_or_fail",
+        lambda _cfg, _override: "https://canvas.test",
+    )
+    monkeypatch.setattr(
+        "canvasctl.cli._run_with_client",
+        lambda _base_url, action: action(fake_client),
+    )
+
+
+def test_grades_summary_json(monkeypatch):
+    runner = CliRunner()
+    _patch(monkeypatch)
+
+    result = runner.invoke(app, ["grades", "summary", "--json"])
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert len(parsed) == 2
+    assert parsed[0]["course_code"] == "BIO101"
+    assert parsed[0]["current_score"] == 92.5
+    assert parsed[0]["current_grade"] == "A-"
+    assert parsed[1]["course_code"] == "MATH201"
+
+
+def test_grades_summary_table(monkeypatch):
+    runner = CliRunner()
+    _patch(monkeypatch)
+
+    result = runner.invoke(app, ["grades", "summary"])
+
+    assert result.exit_code == 0
+    assert "BIO101" in result.output
+    assert "Biology" in result.output
+    assert "A-" in result.output
+    assert "MATH201" in result.output
+
+
+def test_grades_summary_all(monkeypatch):
+    runner = CliRunner()
+    _patch(monkeypatch, fake_client=FakeClientAll())
+
+    result = runner.invoke(app, ["grades", "summary", "--all"])
+
+    assert result.exit_code == 0
+
+
+def test_grades_summary_detailed_json(monkeypatch):
+    runner = CliRunner()
+    _patch(monkeypatch)
+
+    result = runner.invoke(app, ["grades", "summary", "--detailed", "--json"])
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert len(parsed) == 2
+    assert "course" in parsed[0]
+    assert "assignments" in parsed[0]
+    assert parsed[0]["course"]["course_code"] == "BIO101"
+    assert len(parsed[0]["assignments"]) == 2
+    assert parsed[0]["assignments"][0]["assignment_name"] == "Homework 1"
+
+
+def test_grades_summary_detailed_table(monkeypatch):
+    runner = CliRunner()
+    _patch(monkeypatch)
+
+    result = runner.invoke(app, ["grades", "summary", "--detailed"])
+
+    assert result.exit_code == 0
+    assert "Homework 1" in result.output
+    assert "Midterm" in result.output
+    assert "OVERALL" in result.output
+
+
+def test_grades_summary_course_filter(monkeypatch):
+    runner = CliRunner()
+    _patch(monkeypatch)
+
+    result = runner.invoke(app, ["grades", "summary", "--json", "--course", "100"])
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert len(parsed) == 1
+    assert parsed[0]["course_id"] == 100

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from canvasctl.canvas_api import AssignmentGrade, CourseGrade
+from canvasctl.grades import (
+    assignment_grade_to_dict,
+    grade_to_dict,
+    render_detailed_grades_table,
+    render_grades_summary_table,
+    sort_assignment_grades,
+    sort_grades,
+)
+
+
+def _make_course_grade(**overrides) -> CourseGrade:
+    defaults = {
+        "course_id": 1,
+        "course_code": "BIO101",
+        "course_name": "Biology",
+        "current_score": 92.5,
+        "current_grade": "A-",
+    }
+    defaults.update(overrides)
+    return CourseGrade(**defaults)
+
+
+def _make_assignment_grade(**overrides) -> AssignmentGrade:
+    defaults = {
+        "assignment_id": 10,
+        "assignment_name": "Homework 1",
+        "course_id": 1,
+        "points_possible": 100.0,
+        "score": 95.0,
+        "grade": "A",
+        "submitted_at": "2025-01-15T10:00:00Z",
+        "workflow_state": "graded",
+    }
+    defaults.update(overrides)
+    return AssignmentGrade(**defaults)
+
+
+def test_sort_grades_by_code_name_id():
+    grades = [
+        _make_course_grade(course_id=3, course_code="MATH201", course_name="Calculus"),
+        _make_course_grade(course_id=1, course_code="BIO101", course_name="Biology"),
+        _make_course_grade(course_id=2, course_code="BIO101", course_name="Advanced Biology"),
+    ]
+    sorted_grades = sort_grades(grades)
+    assert [g.course_id for g in sorted_grades] == [2, 1, 3]
+
+
+def test_grade_to_dict():
+    grade = _make_course_grade()
+    result = grade_to_dict(grade)
+    assert result["course_id"] == 1
+    assert result["course_code"] == "BIO101"
+    assert result["course_name"] == "Biology"
+    assert result["current_score"] == 92.5
+    assert result["current_grade"] == "A-"
+
+
+def test_assignment_grade_to_dict():
+    ag = _make_assignment_grade()
+    result = assignment_grade_to_dict(ag)
+    assert result["assignment_id"] == 10
+    assert result["assignment_name"] == "Homework 1"
+    assert result["score"] == 95.0
+    assert result["grade"] == "A"
+    assert result["workflow_state"] == "graded"
+
+
+def test_sort_assignment_grades():
+    grades = [
+        _make_assignment_grade(assignment_id=2, assignment_name="Quiz 1"),
+        _make_assignment_grade(assignment_id=1, assignment_name="Homework 1"),
+        _make_assignment_grade(assignment_id=3, assignment_name="Homework 1"),
+    ]
+    sorted_grades = sort_assignment_grades(grades)
+    assert [g.assignment_id for g in sorted_grades] == [1, 3, 2]
+
+
+def test_render_grades_summary_table_has_columns():
+    grades = [_make_course_grade()]
+    table = render_grades_summary_table(grades)
+    column_names = [col.header for col in table.columns]
+    assert "ID" in column_names
+    assert "Course Code" in column_names
+    assert "Course Name" in column_names
+    assert "Letter Grade" in column_names
+    assert "Score (%)" in column_names
+
+
+def test_render_grades_summary_table_na_for_none():
+    grade = _make_course_grade(current_score=None, current_grade=None)
+    table = render_grades_summary_table([grade])
+    # Render the table to check N/A appears
+    from rich.console import Console
+    from io import StringIO
+
+    output = StringIO()
+    console = Console(file=output, width=120)
+    console.print(table)
+    rendered = output.getvalue()
+    assert "N/A" in rendered
+
+
+def test_render_detailed_grades_table_includes_overall():
+    course_grade = _make_course_grade()
+    assignments = [_make_assignment_grade()]
+    table = render_detailed_grades_table(course_grade, assignments)
+
+    from rich.console import Console
+    from io import StringIO
+
+    output = StringIO()
+    console = Console(file=output, width=120)
+    console.print(table)
+    rendered = output.getvalue()
+    assert "OVERALL" in rendered
+    assert "92.5%" in rendered
+    assert "A-" in rendered
+
+
+def test_render_detailed_grades_table_shows_assignments():
+    course_grade = _make_course_grade()
+    assignments = [
+        _make_assignment_grade(assignment_name="Midterm Exam"),
+        _make_assignment_grade(assignment_id=11, assignment_name="Final Paper"),
+    ]
+    table = render_detailed_grades_table(course_grade, assignments)
+
+    from rich.console import Console
+    from io import StringIO
+
+    output = StringIO()
+    console = Console(file=output, width=120)
+    console.print(table)
+    rendered = output.getvalue()
+    assert "Midterm Exam" in rendered
+    assert "Final Paper" in rendered


### PR DESCRIPTION
Add a new `grades` command group with a `summary` subcommand that displays course grades (letter grade + percentage) in a Rich table. Supports --detailed for per-assignment breakdown, --json for machine- readable output, --course to filter specific courses, and --all to include non-active courses.