### PR TITLE
fix: module files not downloaded by sync_course_files

### DIFF
--- a/src/canvasctl/canvas_api.py
+++ b/src/canvasctl/canvas_api.py
@@ -478,7 +478,13 @@ class CanvasClient:
     def list_modules(self, course_id: int) -> list[dict[str, Any]]:
         return self.get_paginated(
             f"/courses/{course_id}/modules",
-            params={"per_page": 100, "include[]": ["items"]},
+            params={"per_page": 100},
+        )
+
+    def list_module_items(self, course_id: int, module_id: int) -> list[dict[str, Any]]:
+        return self.get_paginated(
+            f"/courses/{course_id}/modules/{module_id}/items",
+            params={"per_page": 100},
         )
 
     def mark_module_item_done(

--- a/src/canvasctl/sources.py
+++ b/src/canvasctl/sources.py
@@ -76,7 +76,11 @@ def extract_file_ids_from_payload(payload: Any) -> set[int]:
                         if maybe_id is not None:
                             file_ids.add(maybe_id)
             for key, value in node.items():
-                if key in {"file_id", "attachment_id", "content_id"}:
+                if key in {"file_id", "attachment_id"}:
+                    maybe_id = _coerce_int(value)
+                    if maybe_id is not None:
+                        file_ids.add(maybe_id)
+                if key == "content_id" and node.get("type") == "File":
                     maybe_id = _coerce_int(value)
                     if maybe_id is not None:
                         file_ids.add(maybe_id)
@@ -156,7 +160,15 @@ def _collect_source_items(client: CanvasClient, course_id: int, source_type: str
     if source_type == "pages":
         return client.list_pages(course_id)
     if source_type == "modules":
-        return client.list_modules(course_id)
+        modules = client.list_modules(course_id)
+        all_items: list[dict[str, Any]] = []
+        for module in modules:
+            module_id = module.get("id")
+            if module_id is None:
+                continue
+            items = client.list_module_items(course_id, int(module_id))
+            all_items.extend(items)
+        return all_items
     raise ValueError(f"Unsupported source type: {source_type}")
 
 

--- a/tests/test_canvas_api_new_methods.py
+++ b/tests/test_canvas_api_new_methods.py
@@ -250,7 +250,7 @@ def test_list_modules(monkeypatch):
     with respx.mock(assert_all_called=True) as router:
         router.get("https://canvas.test/api/v1/courses/100/modules").respond(
             200,
-            json=[{"id": 1, "name": "Week 1", "items": []}],
+            json=[{"id": 1, "name": "Week 1"}],
         )
 
         with CanvasClient("https://canvas.test", "token") as client:
@@ -258,6 +258,27 @@ def test_list_modules(monkeypatch):
 
     assert modules[0]["id"] == 1
     assert modules[0]["name"] == "Week 1"
+
+
+def test_list_module_items(monkeypatch):
+    monkeypatch.setattr("canvasctl.canvas_api.time.sleep", lambda _: None)
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("https://canvas.test/api/v1/courses/100/modules/5/items").respond(
+            200,
+            json=[
+                {"id": 10, "type": "File", "content_id": 42, "title": "notes.pdf"},
+                {"id": 11, "type": "Page", "content_id": 99, "title": "Intro"},
+            ],
+        )
+
+        with CanvasClient("https://canvas.test", "token") as client:
+            items = client.list_module_items(100, 5)
+
+    assert len(items) == 2
+    assert items[0]["type"] == "File"
+    assert items[0]["content_id"] == 42
+    assert items[1]["type"] == "Page"
 
 
 def test_mark_module_item_done(monkeypatch):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -47,6 +47,9 @@ class FakeCanvasClient:
     def list_modules(self, course_id: int) -> list[dict[str, Any]]:
         return []
 
+    def list_module_items(self, course_id: int, module_id: int) -> list[dict[str, Any]]:
+        return []
+
     def get_file(self, file_id: int) -> dict[str, Any]:
         self.file_lookup_called.append(file_id)
         return {
@@ -96,18 +99,26 @@ class RestrictedCanvasClient(FakeCanvasClient):
         raise CanvasApiError("Canvas request failed (404) for courses/1/pages")
 
     def list_modules(self, course_id: int) -> list[dict[str, Any]]:
-        return [
-            {
-                "id": 501,
-                "items": [
-                    {
-                        "id": 601,
-                        "title": "Module file",
-                        "html_url": "https://school.instructure.com/files/33/download",
-                    }
-                ],
-            }
-        ]
+        return [{"id": 501, "name": "Module 1"}]
+
+    def list_module_items(self, course_id: int, module_id: int) -> list[dict[str, Any]]:
+        if module_id == 501:
+            return [
+                {
+                    "id": 601,
+                    "title": "Module file",
+                    "type": "File",
+                    "content_id": 33,
+                    "html_url": "https://school.instructure.com/courses/1/files/33",
+                },
+                {
+                    "id": 602,
+                    "title": "Module page",
+                    "type": "Page",
+                    "content_id": 999,
+                },
+            ]
+        return []
 
 
 def test_collect_remote_files_falls_back_to_modules_when_files_blocked():
@@ -122,6 +133,21 @@ def test_collect_remote_files_falls_back_to_modules_when_files_blocked():
     ids = {item.file_id for item in files}
     assert ids == {33}
     assert client.file_lookup_called == [33]
+    assert 999 not in ids
     warning_messages = [warning.detail for warning in warnings]
     assert any("Skipping files source" in message for message in warning_messages)
     assert any("Skipping pages source" in message for message in warning_messages)
+
+
+def test_extract_file_ids_content_id_requires_file_type():
+    file_item = {"type": "File", "content_id": 50}
+    assert 50 in extract_file_ids_from_payload(file_item)
+
+    page_item = {"type": "Page", "content_id": 60}
+    assert 60 not in extract_file_ids_from_payload(page_item)
+
+    assignment_item = {"type": "Assignment", "content_id": 70}
+    assert 70 not in extract_file_ids_from_payload(assignment_item)
+
+    no_type_item = {"content_id": 80}
+    assert 80 not in extract_file_ids_from_payload(no_type_item)


### PR DESCRIPTION
## summary
- module files were silently skipped during sync because `include[]=items` on the modules endpoint can truncate items for large modules, and `content_id` was treated as a file ID for all item types (pages, assignments, etc.) not just files
- added `list_module_items()` to fetch items per-module via the dedicated `/modules/{id}/items` endpoint with proper pagination
- `content_id` is now only extracted as a file ID when the module item has `type == "File"`
- URL pattern extraction (`/files/{id}`) still runs on all strings for backward compatibility

## test plan
- [x] new test: `content_id` with `type: "File"` is extracted, other types are not
- [x] new test: `list_module_items` API method
- [x] updated test: modules fallback uses per-module item fetching with typed items
- [x] full test suite passes (186 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)